### PR TITLE
Task 5.2.2: Implement Authentication Logic & Route Protection

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,18 +1,31 @@
 import { render, screen } from '@testing-library/react'
 import Home from './page'
 
+// Mock UserInfo component
+jest.mock('../components/UserInfo', () => ({
+  UserInfo: () => <div data-testid="user-info">User Info</div>,
+}))
+
 describe('Home', () => {
-  it('renders the "Get started by editing" text', () => {
+  it('renders the welcome title and description', () => {
     render(<Home />)
 
-    const getStartedText = screen.getByText(/Get started by editing/i)
-    expect(getStartedText).toBeInTheDocument()
+    expect(screen.getByText('Welcome to XNote')).toBeInTheDocument()
+    expect(
+      screen.getByText(/The ultimate Markdown editor/i)
+    ).toBeInTheDocument()
   })
 
-  it('displays the correct file path in code block', () => {
+  it('displays authentication status messages', () => {
     render(<Home />)
 
-    const codeElement = screen.getByText('src/app/page.tsx')
-    expect(codeElement).toBeInTheDocument()
+    expect(screen.getByText(/successfully authenticated/i)).toBeInTheDocument()
+    expect(screen.getByText(/protected by middleware/i)).toBeInTheDocument()
+  })
+
+  it('renders the UserInfo component', () => {
+    render(<Home />)
+
+    expect(screen.getByTestId('user-info')).toBeInTheDocument()
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,43 @@
-import Image from "next/image";
+import Image from 'next/image'
+import { UserInfo } from '@/components/UserInfo'
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
+    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-sans sm:p-20">
+      <main className="row-start-2 flex flex-col items-center gap-[32px] sm:items-start">
+        <div className="flex w-full max-w-lg items-center justify-between">
+          <Image
+            className="dark:invert"
+            src="/next.svg"
+            alt="Next.js logo"
+            width={180}
+            height={38}
+            priority
+          />
+          <UserInfo />
+        </div>
+
+        <div className="text-center sm:text-left">
+          <h1 className="mb-4 text-4xl font-bold">Welcome to XNote</h1>
+          <p className="mb-8 text-lg text-gray-600">
+            The ultimate Markdown editor with real-time sync and collaboration.
+          </p>
+        </div>
+
+        <ol className="list-inside list-decimal text-center font-mono text-sm/6 sm:text-left">
           <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
+            You are successfully authenticated and accessing the protected
+            route.
           </li>
           <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
+            This page is protected by middleware - you can only see this when
+            logged in.
           </li>
         </ol>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
+        <div className="flex flex-col items-center gap-4 sm:flex-row">
           <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
+            className="bg-foreground text-background flex h-10 items-center justify-center gap-2 rounded-full border border-solid border-transparent px-4 text-sm font-medium transition-colors hover:bg-[#383838] sm:h-12 sm:w-auto sm:px-5 sm:text-base dark:hover:bg-[#ccc]"
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"
@@ -42,7 +52,7 @@ export default function Home() {
             Deploy now
           </a>
           <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
+            className="flex h-10 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-4 text-sm font-medium transition-colors hover:border-transparent hover:bg-[#f2f2f2] sm:h-12 sm:w-auto sm:px-5 sm:text-base md:w-[158px] dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
             href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"
@@ -51,7 +61,7 @@ export default function Home() {
           </a>
         </div>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
+      <footer className="row-start-3 flex flex-wrap items-center justify-center gap-[24px]">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
@@ -99,5 +109,5 @@ export default function Home() {
         </a>
       </footer>
     </div>
-  );
+  )
 }

--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { useEffect, useState } from 'react'
+import { User } from '@supabase/supabase-js'
+
+export function UserInfo() {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const supabase = createClientComponentClient()
+
+  useEffect(() => {
+    const getUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      setUser(user)
+      setLoading(false)
+    }
+
+    getUser()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      setUser(session?.user ?? null)
+      setLoading(false)
+    })
+
+    return () => subscription.unsubscribe()
+  }, [supabase.auth])
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut()
+  }
+
+  if (loading) {
+    return <div className="text-sm text-gray-500">Loading...</div>
+  }
+
+  if (!user) {
+    return <div className="text-sm text-gray-500">Not signed in</div>
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="text-sm">
+        <div className="font-medium">{user.email}</div>
+        <div className="text-xs text-gray-500">Signed in</div>
+      </div>
+      <button
+        onClick={handleSignOut}
+        className="rounded-md bg-gray-100 px-3 py-1 text-sm transition-colors hover:bg-gray-200"
+      >
+        Sign Out
+      </button>
+    </div>
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,46 @@
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+  const supabase = createMiddlewareClient({ req, res })
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const isAuthPage =
+    req.nextUrl.pathname.startsWith('/login') ||
+    req.nextUrl.pathname.startsWith('/auth/')
+  const isProtectedRoute =
+    req.nextUrl.pathname === '/' || req.nextUrl.pathname.startsWith('/app')
+
+  // If user is not authenticated and trying to access protected route
+  if (!user && isProtectedRoute) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  // If user is authenticated and trying to access auth pages, redirect to home
+  if (
+    user &&
+    isAuthPage &&
+    !req.nextUrl.pathname.startsWith('/auth/callback')
+  ) {
+    return NextResponse.redirect(new URL('/', req.url))
+  }
+
+  return res
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public folder
+     */
+    '/((?!_next/static|_next/image|favicon.ico|public/).*)',
+  ],
+}


### PR DESCRIPTION
## Summary
- Implemented comprehensive authentication middleware with route protection
- Added automatic redirects for unauthenticated/authenticated users
- Enhanced home page with authentication status and user management
- Created UserInfo component with sign out functionality

## Implementation Details

### Middleware (`src/middleware.ts`)
- Uses `createMiddlewareClient` for server-side session checking
- Protects home page (`/`) and future app routes (`/app/*`)
- Redirects unauthenticated users to `/login`
- Prevents authenticated users from accessing auth pages
- Preserves OAuth callback functionality

### Enhanced Home Page
- Updated with XNote branding and clear authentication messaging
- Shows protected route status to confirm middleware working
- Integrated UserInfo component for user management

### UserInfo Component
- Real-time user state management with auth state subscription
- Clean UI showing user email and sign out functionality
- Handles loading states and authentication transitions

## Testing Criteria Met
✓ All 9 tests passing including updated home page tests
✓ Middleware logic correctly implemented and formatted
✓ Route protection covers specified routes (/, /app/*)
✓ Auth pages remain accessible to unauthenticated users
✓ OAuth callback route excluded from auth page redirects

## Manual Testing Instructions
1. **Navigate to `/` without authentication** → Should redirect to `/login`
2. **Sign up/sign in via email or social providers** → Should redirect to `/` and show authenticated content  
3. **Access login page while authenticated** → Should redirect to `/`
4. **Use Sign Out button** → Should sign out and redirect to `/login`

## Files Changed
- `src/middleware.ts` - Core authentication middleware with route protection
- `src/app/page.tsx` - Enhanced home page with authentication integration
- `src/components/UserInfo.tsx` - User management component  
- `src/app/page.test.tsx` - Updated tests for new page content

🤖 Generated with [Claude Code](https://claude.ai/code)