### PR TITLE
fix(editor): add Element.append polyfill for Vercel environment

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -20,6 +20,16 @@ export function Editor({
   const viewRef = useRef<any>(null)
 
   useEffect(() => {
+    // Polyfill for Element.prototype.append for compatibility
+    if (typeof window !== 'undefined' && !Element.prototype.append) {
+      Element.prototype.append = function (...args) {
+        for (const arg of args) {
+          this.appendChild(
+            arg instanceof Node ? arg : document.createTextNode(String(arg))
+          )
+        }
+      }
+    }
     if (!editorRef.current) return
 
     // Ensure we're in a proper browser environment with full DOM support


### PR DESCRIPTION
Adds a polyfill for `Element.prototype.append` within the Editor component's `useEffect` hook. This resolves a `TypeError: e.append is not a function` error that occurs during ProseMirror initialization in environments where this method is not natively supported, such as the one encountered on Vercel.